### PR TITLE
Fixed haddock error in Data.MessagePack

### DIFF
--- a/src/Data/MessagePack.hs
+++ b/src/Data/MessagePack.hs
@@ -13,9 +13,9 @@
 --
 --------------------------------------------------------------------
 
-module Data.MessagePack
+module Data.MessagePack (
   -- * Simple interface to pack and unpack msgpack binary
-  ( pack
+    pack
   , unpack
 
   -- * Re-export modules


### PR DESCRIPTION
I was getting the following haddock error:

```
src/Data/MessagePack.hs:17:3: error:
    parse error on input ‘-- * Simple interface to pack and unpack msgpack binary’
```
