### PR TITLE
Fix MessagePack Integer implementation

### DIFF
--- a/src/Data/MessagePack/Class.hs
+++ b/src/Data/MessagePack/Class.hs
@@ -81,22 +81,36 @@ toInt = fromIntegral
 fromInt :: Integral a => Int64 -> a
 fromInt = fromIntegral
 
+toWord :: Integral a => a -> Word64
+toWord = fromIntegral
+
+fromWord :: Integral a => Word64 -> a
+fromWord = fromIntegral
+
 instance MessagePack Int64 where
-  toObject = ObjectInt
+  toObject i
+    | i < 0 = ObjectInt i
+    | otherwise = ObjectWord $ toWord i
   fromObject = \case
-    ObjectInt n -> return n
-    _           -> fail "invalid encoding for integer type"
+    ObjectInt n  -> return n
+    ObjectWord n -> return $ toInt n
+    _            -> fail "invalid encoding for integer type"
+
+instance MessagePack Word64 where
+  toObject = ObjectWord
+  fromObject = \case
+    ObjectWord n -> return n
+    _            -> fail "invalid encoding for integer type"
 
 instance MessagePack Int    where { toObject = toObject . toInt; fromObject o = fromInt <$> fromObject o }
 instance MessagePack Int8   where { toObject = toObject . toInt; fromObject o = fromInt <$> fromObject o }
 instance MessagePack Int16  where { toObject = toObject . toInt; fromObject o = fromInt <$> fromObject o }
 instance MessagePack Int32  where { toObject = toObject . toInt; fromObject o = fromInt <$> fromObject o }
 
-instance MessagePack Word   where { toObject = toObject . toInt; fromObject o = fromInt <$> fromObject o }
-instance MessagePack Word8  where { toObject = toObject . toInt; fromObject o = fromInt <$> fromObject o }
-instance MessagePack Word16 where { toObject = toObject . toInt; fromObject o = fromInt <$> fromObject o }
-instance MessagePack Word32 where { toObject = toObject . toInt; fromObject o = fromInt <$> fromObject o }
-instance MessagePack Word64 where { toObject = toObject . toInt; fromObject o = fromInt <$> fromObject o }
+instance MessagePack Word   where { toObject = toObject . toWord; fromObject o = fromWord <$> fromObject o }
+instance MessagePack Word8  where { toObject = toObject . toWord; fromObject o = fromWord <$> fromObject o }
+instance MessagePack Word16 where { toObject = toObject . toWord; fromObject o = fromWord <$> fromObject o }
+instance MessagePack Word32 where { toObject = toObject . toWord; fromObject o = fromWord <$> fromObject o }
 
 
 -- Core instances.
@@ -122,6 +136,7 @@ instance MessagePack Float where
   toObject = ObjectFloat
   fromObject = \case
     ObjectInt    n -> return $ fromIntegral n
+    ObjectWord   n -> return $ fromIntegral n
     ObjectFloat  f -> return f
     ObjectDouble d -> return $ realToFrac d
     _              -> fail "invalid encoding for Float"
@@ -130,6 +145,7 @@ instance MessagePack Double where
   toObject = ObjectDouble
   fromObject = \case
     ObjectInt    n -> return $ fromIntegral n
+    ObjectWord   n -> return $ fromIntegral n
     ObjectFloat  f -> return $ realToFrac f
     ObjectDouble d -> return d
     _              -> fail "invalid encoding for Double"

--- a/src/Data/MessagePack/Generic.hs
+++ b/src/Data/MessagePack/Generic.hs
@@ -37,7 +37,7 @@ instance (GSumPack a, GSumPack b, SumSize a, SumSize b) => GMessagePack (a :+: b
       size = unTagged (sumSize :: Tagged (a :+: b) Word64)
 
   gFromObject = \case
-    ObjectInt code -> checkSumFromObject0 size (fromIntegral code)
+    ObjectWord code -> checkSumFromObject0 size (fromIntegral code)
     o              -> fromObject o >>= uncurry (checkSumFromObject size)
     where
       size = unTagged (sumSize :: Tagged (a :+: b) Word64)

--- a/src/Data/MessagePack/Generic.hs
+++ b/src/Data/MessagePack/Generic.hs
@@ -38,7 +38,7 @@ instance (GSumPack a, GSumPack b, SumSize a, SumSize b) => GMessagePack (a :+: b
 
   gFromObject = \case
     ObjectWord code -> checkSumFromObject0 size (fromIntegral code)
-    o              -> fromObject o >>= uncurry (checkSumFromObject size)
+    o               -> fromObject o >>= uncurry (checkSumFromObject size)
     where
       size = unTagged (sumSize :: Tagged (a :+: b) Word64)
 

--- a/src/Data/MessagePack/Get.hs
+++ b/src/Data/MessagePack/Get.hs
@@ -19,6 +19,7 @@ module Data.MessagePack.Get
   ( getNil
   , getBool
   , getInt
+  , getWord
   , getFloat
   , getDouble
   , getStr
@@ -39,7 +40,7 @@ import qualified Data.ByteString     as S
 import           Data.Int            (Int16, Int32, Int64, Int8)
 import qualified Data.Text           as T
 import qualified Data.Text.Encoding  as T
-import           Data.Word           (Word8)
+import           Data.Word           (Word64, Word8)
 
 getNil :: Get ()
 getNil = tag 0xC0
@@ -52,18 +53,23 @@ getBool =
 getInt :: Get Int64
 getInt =
   getWord8 >>= \case
-    c | c .&. 0x80 == 0x00 ->
-        return $ fromIntegral c
-      | c .&. 0xE0 == 0xE0 ->
+    c | c .&. 0xE0 == 0xE0 ->
         return $ fromIntegral (fromIntegral c :: Int8)
-    0xCC -> fromIntegral <$> getWord8
-    0xCD -> fromIntegral <$> getWord16be
-    0xCE -> fromIntegral <$> getWord32be
-    0xCF -> fromIntegral <$> getWord64be
     0xD0 -> fromIntegral <$> getInt8
     0xD1 -> fromIntegral <$> getInt16be
     0xD2 -> fromIntegral <$> getInt32be
     0xD3 -> fromIntegral <$> getInt64be
+    _    -> empty
+
+getWord :: Get Word64
+getWord =
+  getWord8 >>= \case
+    c | c .&. 0x80 == 0x00 ->
+        return $ fromIntegral c
+    0xCC -> fromIntegral <$> getWord8
+    0xCD -> fromIntegral <$> getWord16be
+    0xCE -> fromIntegral <$> getWord32be
+    0xCF -> fromIntegral <$> getWord64be
     _    -> empty
 
 getFloat :: Get Float

--- a/src/Data/MessagePack/Object.hs
+++ b/src/Data/MessagePack/Object.hs
@@ -101,7 +101,7 @@ instance Arbitrary Object where
     , ObjectMap    <$> Gen.resize (n `div` 4) arbitrary
     , ObjectExt    <$> arbitrary <*> arbitrary
     ]
-    where negatives = Gen.choose (-0X7FFFFFFFFFFFFFFF, -1)
+    where negatives = Gen.choose (minBound, -1)
 
 instance Arbitrary S.ByteString where
   arbitrary = S.pack <$> arbitrary

--- a/src/Data/MessagePack/Object.hs
+++ b/src/Data/MessagePack/Object.hs
@@ -14,7 +14,7 @@ import           Data.Int                  (Int64)
 import qualified Data.Text                 as T
 import qualified Data.Text.Lazy            as LT
 import           Data.Typeable             (Typeable)
-import           Data.Word                 (Word8)
+import           Data.Word                 (Word64, Word8)
 import           GHC.Generics              (Generic)
 import           Prelude                   hiding (putStr)
 import           Test.QuickCheck.Arbitrary (Arbitrary, arbitrary)
@@ -31,7 +31,9 @@ data Object
   | ObjectBool                  !Bool
     -- ^ represents true or false
   | ObjectInt    {-# UNPACK #-} !Int64
-    -- ^ represents an integer
+    -- ^ represents a negative integer
+  | ObjectWord   {-# UNPACK #-} !Word64
+    -- ^ represents a positive integer
   | ObjectFloat  {-# UNPACK #-} !Float
     -- ^ represents a floating point number
   | ObjectDouble {-# UNPACK #-} !Double
@@ -61,6 +63,7 @@ getObject =
       ObjectNil    <$  getNil
   <|> ObjectBool   <$> getBool
   <|> ObjectInt    <$> getInt
+  <|> ObjectWord   <$> getWord
   <|> ObjectFloat  <$> getFloat
   <|> ObjectDouble <$> getDouble
   <|> ObjectStr    <$> getStr
@@ -74,6 +77,7 @@ putObject = \case
   ObjectNil      -> putNil
   ObjectBool   b -> putBool b
   ObjectInt    n -> putInt n
+  ObjectWord   n -> putWord n
   ObjectFloat  f -> putFloat f
   ObjectDouble d -> putDouble d
   ObjectStr    t -> putStr t
@@ -87,7 +91,8 @@ instance Arbitrary Object where
   arbitrary = Gen.sized $ \n -> Gen.oneof
     [ return ObjectNil
     , ObjectBool   <$> arbitrary
-    , ObjectInt    <$> arbitrary
+    , ObjectInt    <$> negatives
+    , ObjectWord   <$> arbitrary
     , ObjectFloat  <$> arbitrary
     , ObjectDouble <$> arbitrary
     , ObjectStr    <$> arbitrary
@@ -96,6 +101,7 @@ instance Arbitrary Object where
     , ObjectMap    <$> Gen.resize (n `div` 4) arbitrary
     , ObjectExt    <$> arbitrary <*> arbitrary
     ]
+    where negatives = Gen.choose (-0X7FFFFFFFFFFFFFFF, -1)
 
 instance Arbitrary S.ByteString where
   arbitrary = S.pack <$> arbitrary

--- a/src/Data/MessagePack/Put.hs
+++ b/src/Data/MessagePack/Put.hs
@@ -17,6 +17,7 @@ module Data.MessagePack.Put
   ( putNil
   , putBool
   , putInt
+  , putWord
   , putFloat
   , putDouble
   , putStr
@@ -35,7 +36,7 @@ import qualified Data.ByteString     as S
 import           Data.Int            (Int64)
 import qualified Data.Text           as T
 import qualified Data.Text.Encoding  as T
-import           Data.Word           (Word8)
+import           Data.Word           (Word64, Word8)
 
 import           Prelude             hiding (putStr)
 
@@ -66,6 +67,19 @@ putInt n
     putWord8 0xD2 >> putWord32be  (fromIntegral n)
   | otherwise =
     putWord8 0xD3 >> putWord64be (fromIntegral n)
+
+putWord :: Word64 -> Put
+putWord n
+  | n < 0x80 =
+                     putWord8     (fromIntegral n)
+  | n < 0x100 =
+    putWord8 0xCC >> putWord8     (fromIntegral n)
+  | n < 0x10000 =
+    putWord8 0xCD >> putWord16be  (fromIntegral n)
+  | n < 0x100000000 =
+    putWord8 0xCE >> putWord32be  (fromIntegral n)
+  | otherwise =
+    putWord8 0xCF >> putWord64be  n
 
 putFloat :: Float -> Put
 putFloat f = do

--- a/test/Data/MessagePackSpec.hs
+++ b/test/Data/MessagePackSpec.hs
@@ -321,8 +321,11 @@ spec = do
     it "Foo" $ do
       show (toObject Foo1) `shouldBe` "ObjectWord 0"
       show (toObject $ Foo3 3) `shouldBe` "ObjectArray [ObjectWord 2,ObjectWord 3]"
+      show (toObject $ Foo3 (-3)) `shouldBe` "ObjectArray [ObjectWord 2,ObjectInt (-3)]"
       show (toObject $ Foo9 3 5) `shouldBe` "ObjectArray [ObjectWord 8,ObjectArray [ObjectWord 3,ObjectWord 5]]"
+      show (toObject $ Foo9 (-3) (-5)) `shouldBe` "ObjectArray [ObjectWord 8,ObjectArray [ObjectInt (-3),ObjectInt (-5)]]"
       show (toObject $ Foo10 3 5 7) `shouldBe` "ObjectArray [ObjectWord 9,ObjectArray [ObjectWord 3,ObjectWord 5,ObjectWord 7]]"
+      show (toObject $ Foo10 (-3) (-5) 7) `shouldBe` "ObjectArray [ObjectWord 9,ObjectArray [ObjectInt (-3),ObjectInt (-5),ObjectWord 7]]"
 
     it "Record" $
       show (toObject $ Record 3 5 7) `shouldBe` "ObjectArray [ObjectWord 3,ObjectWord 5,ObjectWord 7]"

--- a/test/Data/MessagePackSpec.hs
+++ b/test/Data/MessagePackSpec.hs
@@ -314,13 +314,13 @@ spec = do
 
   describe "show" $ do
     it "Foo" $ do
-      show (toObject Foo1) `shouldBe` "ObjectInt 0"
-      show (toObject $ Foo3 3) `shouldBe` "ObjectArray [ObjectInt 2,ObjectInt 3]"
-      show (toObject $ Foo9 3 5) `shouldBe` "ObjectArray [ObjectInt 8,ObjectArray [ObjectInt 3,ObjectInt 5]]"
-      show (toObject $ Foo10 3 5 7) `shouldBe` "ObjectArray [ObjectInt 9,ObjectArray [ObjectInt 3,ObjectInt 5,ObjectInt 7]]"
+      show (toObject Foo1) `shouldBe` "ObjectWord 0"
+      show (toObject $ Foo3 3) `shouldBe` "ObjectArray [ObjectWord 2,ObjectWord 3]"
+      show (toObject $ Foo9 3 5) `shouldBe` "ObjectArray [ObjectWord 8,ObjectArray [ObjectWord 3,ObjectWord 5]]"
+      show (toObject $ Foo10 3 5 7) `shouldBe` "ObjectArray [ObjectWord 9,ObjectArray [ObjectWord 3,ObjectWord 5,ObjectWord 7]]"
 
     it "Record" $
-      show (toObject $ Record 3 5 7) `shouldBe` "ObjectArray [ObjectInt 3,ObjectInt 5,ObjectInt 7]"
+      show (toObject $ Record 3 5 7) `shouldBe` "ObjectArray [ObjectWord 3,ObjectWord 5,ObjectWord 7]"
 
 voidTest :: Void -> Object
 voidTest = toObject

--- a/test/Data/MessagePackSpec.hs
+++ b/test/Data/MessagePackSpec.hs
@@ -11,6 +11,7 @@ import qualified Test.QuickCheck.Gen        as Gen
 
 import           Control.Applicative        ((<$>), (<*>))
 import qualified Data.ByteString.Char8      as S
+import qualified Data.ByteString.Lazy       as L8
 import qualified Data.ByteString.Lazy.Char8 as L
 import           Data.Hashable              (Hashable)
 import qualified Data.HashMap.Strict        as HashMap
@@ -311,6 +312,10 @@ spec = do
       property $ \(a :: Foo) -> a `shouldBe` mid a
     it "arbitrary message" $
       property $ \(a :: Object) -> a `shouldBe` mid a
+
+  describe "encoding validation" $ do
+    it "word64 2^64-1" $
+      pack (0xffffffffffffffff :: Word64) `shouldBe` L8.pack [0xCF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
 
   describe "show" $ do
     it "Foo" $ do


### PR DESCRIPTION
MessagePack spec declares Int as `[-(2^63-1), 2^64-1]` and encodes negatives (< 0) and non-negatives (>= 0) differently.

`data-msgpack` implementation used Int64 to store both negative and positive values, which in result caused values > 2^63 to be encoded as negative values.

Your tests didn't fail because Word64 -> Int64 -> Word64 would convert just fine. But any other MessagePack implementations would read a negative value (or fail, if positive is expected).

Fixes https://github.com/TokTok/hs-msgpack/issues/15.
