### PR TITLE
Add lower binary package version boundary

### DIFF
--- a/data-msgpack.cabal
+++ b/data-msgpack.cabal
@@ -42,7 +42,7 @@ library
   build-depends:
       base < 5
     , QuickCheck
-    , binary
+    , binary >= 0.7.0.0
     , bytestring
     , containers
     , data-binary-ieee754


### PR DESCRIPTION
`decodeOrFail` function's been added to package with version `0.7.0.0`.
Older `binary` versions are not acceptable.
