### PR TITLE
Test that empty arrays can be decoded as ().

### DIFF
--- a/test/Data/MessagePackSpec.hs
+++ b/test/Data/MessagePackSpec.hs
@@ -349,6 +349,9 @@ spec = do
     it "word64 2^64-1" $
       pack (0xffffffffffffffff :: Word64) `shouldBe` L8.pack [0xCF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
 
+    it "decodes empty array as ()" $
+      unpack (pack ([] :: [Int])) `shouldBe` Just ()
+
   describe "show" $ do
     it "Foo" $ do
       show (toObject Foo1) `shouldBe` "ObjectWord 0"


### PR DESCRIPTION
This was the old behaviour. The new behaviour is to encode () as nil,
but we still support the old behaviour in the decoder.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-msgpack/24)

<!-- Reviewable:end -->
