### PR TITLE
Add benchmark modules to extra-source-files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ script:
   - cabal test
 
 after_script:
-  - TESTSUITE=data-msgpack-0.0.6
+  - TESTSUITE=data-msgpack-0.0.8
   - cp dist/hpc/mix/testsuite/*.mix dist/hpc/mix/$TESTSUITE/
   - hpc-coveralls $TESTSUITE

--- a/data-msgpack.cabal
+++ b/data-msgpack.cabal
@@ -1,5 +1,5 @@
 name:                 data-msgpack
-version:              0.0.6
+version:              0.0.8
 synopsis:             A Haskell implementation of MessagePack
 homepage:             http://msgpack.org/
 license:              BSD3

--- a/data-msgpack.cabal
+++ b/data-msgpack.cabal
@@ -18,6 +18,12 @@ description:
   since the original author is unreachable. This fork incorporates a number of
   bugfixes and is actively being developed.
 
+extra-source-files:
+  bench/Data/MessagePack/*.hs
+  bench/Data/*.hs
+  test/Data/MessagePack/*.hs
+  test/Data/*.hs
+
 source-repository head
   type:             git
   location:         https://github.com/TokTok/hs-msgpack.git


### PR DESCRIPTION
`cabal sdist` doesn't include bench modules.

Fixes #20
Fixes #25

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-msgpack/26)

<!-- Reviewable:end -->
