### PR TITLE
Add `Data.MessagePack.Option` type for nullable fields.

### DIFF
--- a/data-msgpack.cabal
+++ b/data-msgpack.cabal
@@ -37,6 +37,7 @@ library
       Data.MessagePack.Get
       Data.MessagePack.Instances
       Data.MessagePack.Object
+      Data.MessagePack.Option
       Data.MessagePack.Put
       Data.MessagePack.Result
   build-depends:
@@ -73,6 +74,7 @@ test-suite testsuite
   hs-source-dirs: test
   main-is: testsuite.hs
   other-modules:
+      Data.MessagePack.OptionSpec
       Data.MessagePack.ResultSpec
       Data.MessagePackSpec
   ghc-options:

--- a/src/Data/MessagePack.hs
+++ b/src/Data/MessagePack.hs
@@ -34,6 +34,7 @@ import           Data.MessagePack.Generic   ()
 import           Data.MessagePack.Get       as X
 import           Data.MessagePack.Instances as X
 import           Data.MessagePack.Object    as X
+import           Data.MessagePack.Option    as X
 import           Data.MessagePack.Put       as X
 
 

--- a/src/Data/MessagePack/Option.hs
+++ b/src/Data/MessagePack/Option.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveFoldable     #-}
+{-# LANGUAGE DeriveFunctor      #-}
+{-# LANGUAGE DeriveTraversable  #-}
+module Data.MessagePack.Option
+  ( Option (..)
+  ) where
+
+import           Control.Applicative       (Alternative (..), Applicative (..),
+                                            (<$>))
+import           Control.Monad             (Monad (..), MonadPlus (..))
+import           Data.Data                 (Data)
+import           Data.Foldable             (Foldable)
+import           Data.Traversable          (Traversable)
+import           Data.Typeable             (Typeable)
+import           Test.QuickCheck.Arbitrary (Arbitrary (..))
+import qualified Test.QuickCheck.Gen       as Gen
+
+import           Data.MessagePack.Class    (MessagePack (..))
+import           Data.MessagePack.Object   (Object (..))
+
+
+data Option a
+  = None
+  | Some a
+  deriving (Eq, Ord, Show, Read, Foldable, Functor, Traversable, Data, Typeable)
+
+instance Applicative Option where
+  pure = Some
+
+  Some f <*> m = fmap f m
+  None   <*> _ = None
+
+instance Monad Option where
+  return = Some
+  fail _ = None
+
+  None   >>= _ = None
+  Some x >>= f = f x
+
+instance Alternative Option where
+  empty = None
+
+  None <|> x = x
+  x    <|> _ = x
+
+instance MonadPlus Option where
+  mzero = empty
+  mplus = (<|>)
+
+instance MessagePack a => MessagePack (Option a) where
+  toObject None = ObjectNil
+  toObject (Some a) = toObject a
+
+  fromObject ObjectNil = return None
+  fromObject x = Some <$> fromObject x
+
+instance Arbitrary a => Arbitrary (Option a) where
+  arbitrary = Gen.oneof
+    [ pure None
+    , Some <$> arbitrary
+    ]

--- a/test/Data/MessagePackSpec.hs
+++ b/test/Data/MessagePackSpec.hs
@@ -312,6 +312,8 @@ spec = do
       property $ \(a :: IntMap.IntMap Int) -> a `shouldBe` mid a
     it "HashMap String Int" $
       property $ \(a :: HashMap.HashMap String Int) -> a `shouldBe` mid a
+    it "Option Int" $
+      property $ \(a :: Option Int) -> a `shouldBe` mid a
     it "maybe int" $
       property $ \(a :: Maybe Int) -> a `shouldBe` mid a
     it "maybe nil" $


### PR DESCRIPTION
This behaves like Maybe in every respect, except that it has a different
msgpack representation. Where `Nothing` is encoded as 0 and `Just x` is
encoded as `[1, toObject x]`, `Options` are encoded as `nil` or `toObject
x`. This makes `Option` unnestable. It's still possible to nest Options,
but decoding an encoded `Some None` will result in `None`.

Fixes #17.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-msgpack/34)
<!-- Reviewable:end -->
