### PR TITLE
Add GHC warning flags to bazel build.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,6 +3,11 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_library", "haskell
 haskell_library(
     name = "hs-msgpack",
     srcs = glob(["src/**/*.*hs"]),
+    compiler_flags = [
+        "-Wall",
+        "-Werror",
+        "-Wno-unused-imports",
+    ],
     prebuilt_dependencies = [
         "base",
         "binary",
@@ -20,6 +25,11 @@ haskell_library(
 haskell_test(
     name = "test",
     srcs = glob(["test/**/*.hs"]),
+    compiler_flags = [
+        "-Wall",
+        "-Werror",
+        "-Wno-unused-imports",
+    ],
     main_file = "test/testsuite.hs",
     prebuilt_dependencies = [
         "base",

--- a/src/Data/MessagePack.hs
+++ b/src/Data/MessagePack.hs
@@ -24,7 +24,7 @@ module Data.MessagePack (
   , module X
   ) where
 
-import           Control.Applicative    (Applicative, (<|>))
+import           Control.Applicative    (Applicative)
 import           Control.Monad          ((>=>))
 import           Data.Binary            (Binary (..), decodeOrFail, encode)
 import qualified Data.ByteString.Lazy   as L

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_binary")
+
+haskell_binary(
+    name = "msgpack-parser",
+    srcs = ["msgpack-parser.hs"],
+    compiler_flags = [
+        "-Wall",
+        "-Werror",
+        "-Wno-unused-imports",
+    ],
+    main_file = "msgpack-parser.hs",
+    prebuilt_dependencies = [
+        "base",
+        "bytestring",
+    ],
+    deps = [
+        "//hs-msgpack",
+        "@haskell_groom//:groom",
+    ],
+)


### PR DESCRIPTION
`-Werror` is fine here because we control the exact version of GHC we are
building with (currently 8.2.2), so there is no risk of getting different
warnings on different installations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-msgpack/52)
<!-- Reviewable:end -->
