### PR TITLE
Remove standard_travis setting in BUILD.bazel.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,10 +3,7 @@ load("@rules_haskell//haskell:defs.bzl", "haskell_library")
 load("//third_party/haskell/hspec-discover:build_defs.bzl", "hspec_test")
 load("//tools/project:build_defs.bzl", "project")
 
-project(
-    license = "hs-msgpack",
-    standard_travis = True,
-)
+project(license = "hs-msgpack")
 
 haskell_library(
     name = "hs-msgpack-binary",


### PR DESCRIPTION
This is becoming the default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-msgpack-binary/72)
<!-- Reviewable:end -->
