### PR TITLE
cleanup: Add "base" version check for "fail" in "Monad"

### DIFF
--- a/test/Data/Result.hs
+++ b/test/Data/Result.hs
@@ -21,7 +21,9 @@ instance Applicative Result where
 
 instance Monad Result where
     return = Success
+#if !MIN_VERSION_base(4,13,0)
     fail = Failure
+#endif
 
     Success x   >>= f = f x
     Failure msg >>= _ = Failure msg


### PR DESCRIPTION
`fail` was removed from `Monad` since `base-4.13.0.0` (GHC 8.8).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-msgpack-binary/76)
<!-- Reviewable:end -->
